### PR TITLE
feat: add use-failcraft Claude skill

### DIFF
--- a/skills/use-failcraft/SKILL.md
+++ b/skills/use-failcraft/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: failcraft
+description: 'Apply failcraft functional error handling conventions. Use when developers: (1) Handle errors without try/catch, (2) Work with Either, Left, or Right, (3) Chain async operations that may fail, (4) Use trySync or tryAsync, (5) Ask about left, right, transform, andThen, orDefault, getOrThrow, match, or on. Triggers on: "Either", "left", "right", "AsyncEither", "trySync", "tryAsync", "failcraft", "functional error handling".'
+---
+
+## Critical: Follow failcraft Conventions
+
+Everything you know about error handling may differ from how failcraft implements it. Always follow the rules below — never use `throw`/`try/catch` where `Either` is expected.
+
+When working with failcraft:
+
+1. Import only from `failcraft` — `Either` and `Left`/`Right` are type-only imports
+2. Never throw inside a function that returns `Either` — return `left(error)` instead
+3. Never construct `AsyncEither` directly — obtain it from `transformAsync`, `andThenAsync`, or `tryAsync`
+4. Use `trySync` / `tryAsync` to wrap third-party code that may throw
+5. Use `match` for exhaustive handling; use `on` only for side effects (logging, metrics)
+6. `Left` is the error side, `Right` is the success side — preserve this consistently
+
+If you are unsure about a pattern, check [API Reference](references/api.md) and [Patterns](references/patterns.md) before writing code.
+
+## Imports
+
+```ts
+import { type Either, type Left, type Right, left, right, trySync, tryAsync } from 'failcraft'
+```
+
+`Either`, `Left`, and `Right` are **type-only** — they cannot be used as values. See [API Reference](references/api.md).
+
+## Either
+
+The core type: `Either<L, R>` is either a `Left<L>` (error) or a `Right<R>` (success).
+
+- Use `left(value)` and `right(value)` as constructors
+- Narrow with `isLeft()` / `isRight()` or their aliases `isError()` / `isSuccess()`
+- Return `Either` from functions — never throw
+
+```ts
+function divide(a: number, b: number): Either<string, number> {
+  if (b === 0) return left("division by zero")
+  return right(a / b)
+}
+```
+
+See [Patterns](references/patterns.md) for chaining, async, and unwrapping examples.
+
+## AsyncEither
+
+A promise-based wrapper with the full `Either` chainable API. **Never construct directly.**
+
+Obtain via:
+- `either.transformAsync(async fn)` — maps right to async result
+- `either.andThenAsync(async fn)` — chains async Either-returning fn
+- `tryAsync(() => promise)` — wraps a Promise that may reject
+
+```ts
+right(userId)
+  .transformAsync(async (id) => fetchUser(id))
+  .andThen((user) => validateUser(user))
+  .match({ left: handleError, right: handleSuccess })
+```
+
+## Try Helpers
+
+Use when wrapping third-party code that throws:
+
+```ts
+// Sync — fn must be wrapped in () =>
+const result = trySync(() => JSON.parse(raw)) // Either<unknown, unknown>
+
+// Async — fn must return a Promise
+const result = tryAsync(() => fetch(url).then(r => r.json())) // AsyncEither<unknown, unknown>
+```
+
+**Never** call `trySync(JSON.parse(raw))` — the argument is evaluated before `trySync` can catch it.
+
+## References
+
+- [API Reference](references/api.md) — full type signatures and method descriptions
+- [Patterns](references/patterns.md) — chaining, async, unwrapping, and real-world examples

--- a/skills/use-failcraft/references/api.md
+++ b/skills/use-failcraft/references/api.md
@@ -1,0 +1,100 @@
+# API Reference
+
+## Imports
+
+```ts
+import { type Either, type Left, type Right, left, right, trySync, tryAsync } from 'failcraft'
+```
+
+`Either`, `Left`, `Right` are **type-only**. `left`, `right`, `trySync`, `tryAsync` are runtime values.
+
+---
+
+## `left(value)` / `right(value)`
+
+Constructors for `Either<L, R>`.
+
+```ts
+const fail = left("not found")   // Either<string, never>
+const ok   = right(42)           // Either<never, number>
+```
+
+---
+
+## `Either<L, R>`
+
+Abstract type — always a `Left<L>` or `Right<R>` at runtime.
+
+### Narrowing
+
+| Method | Returns | Description |
+|---|---|---|
+| `.isLeft()` | `this is Left<L, R>` | True when left |
+| `.isRight()` | `this is Right<R, L>` | True when right |
+| `.isError()` | `this is Left<L, R>` | Alias for `isLeft()` |
+| `.isSuccess()` | `this is Right<R, L>` | Alias for `isRight()` |
+
+### Transformation (right only — left passes through)
+
+| Method | Returns | Description |
+|---|---|---|
+| `.transform(fn)` | `Either<L, T>` | Maps right value synchronously |
+| `.andThen(fn)` | `Either<L, T>` | Chains an `Either`-returning fn; flattens |
+| `.transformAsync(fn)` | `AsyncEither<L, T>` | Maps right value asynchronously |
+| `.andThenAsync(fn)` | `AsyncEither<L, T>` | Chains an async `Either`-returning fn |
+
+### Unwrapping
+
+| Method | Returns | Description |
+|---|---|---|
+| `.orDefault(value)` | `R` | Returns right value or fallback |
+| `.getOrThrow()` | `R` | Returns right or throws left value |
+| `.getOrThrowWith(fn)` | `R` | Returns right or throws `fn(leftValue)` |
+
+### Pattern matching
+
+| Method | Returns | Description |
+|---|---|---|
+| `.match({ left, right })` | `T` | Exhaustive — both branches required |
+| `.on({ left?, right? })` | `this` | Side-effect tap; returns `this` for chaining |
+
+---
+
+## `AsyncEither<L, R>`
+
+Promise-based wrapper. **Never construct directly** — obtain from `transformAsync`, `andThenAsync`, or `tryAsync`.
+
+| Method | Returns | Description |
+|---|---|---|
+| `.transform(fn)` | `AsyncEither<L, T>` | Sync map on resolved right |
+| `.andThen(fn)` | `AsyncEither<L, T>` | Sync Either chain on resolved right |
+| `.transformAsync(fn)` | `AsyncEither<L, T>` | Async map on resolved right |
+| `.andThenAsync(fn)` | `AsyncEither<L, T>` | Async Either chain on resolved right |
+| `.match({ left, right })` | `Promise<T>` | Exhaustive match; returns Promise |
+| `.on({ left?, right? })` | `AsyncEither<L, R>` | Side-effect tap |
+| `.orDefault(value)` | `Promise<R>` | Resolves to right or fallback |
+| `.getOrThrow()` | `Promise<R>` | Resolves to right or rejects with left |
+| `.getOrThrowWith(fn)` | `Promise<R>` | Resolves to right or rejects with `fn(left)` |
+| `.toPromise()` | `Promise<Either<L, R>>` | Unwraps to raw `Promise<Either>` |
+
+---
+
+## `trySync(fn)`
+
+```ts
+trySync<L, R>(fn: () => R): Either<L, R>
+```
+
+Executes `fn` inside a try/catch. Returns `right(result)` on success, `left(error)` on throw.
+
+`fn` **must be wrapped in `() =>`** — arguments are evaluated before the function call.
+
+---
+
+## `tryAsync(fn)`
+
+```ts
+tryAsync<L, R>(fn: () => Promise<R>): AsyncEither<L, R>
+```
+
+Wraps a Promise factory. Returns `AsyncEither` resolving to `right(value)` or `left(error)`.

--- a/skills/use-failcraft/references/patterns.md
+++ b/skills/use-failcraft/references/patterns.md
@@ -1,0 +1,134 @@
+# Patterns
+
+## Returning Either from a function
+
+Never throw — return `left` for errors, `right` for success.
+
+```ts
+import { type Either, left, right } from 'failcraft'
+
+function findUser(id: string): Either<string, User> {
+  const user = db.find(id)
+  if (!user) return left("user not found")
+  return right(user)
+}
+```
+
+---
+
+## Chaining with transform / andThen
+
+Use `transform` to map the right value, `andThen` to chain another `Either`-returning function.
+Left values short-circuit — subsequent steps are skipped.
+
+```ts
+findUser(id)
+  .transform((user) => user.email)          // Either<string, string>
+  .andThen((email) => validateEmail(email)) // Either<string, Email>
+  .orDefault("fallback@example.com")
+```
+
+---
+
+## Pattern matching
+
+Use `match` when you need a value from both branches:
+
+```ts
+const message = findUser(id).match({
+  left: (err) => `Error: ${err}`,
+  right: (user) => `Hello, ${user.name}`,
+})
+```
+
+Use `on` for side effects only — it returns `this` and does not transform:
+
+```ts
+findUser(id)
+  .on({ left: (err) => logger.warn(err) })
+  .transform((user) => user.name)
+```
+
+---
+
+## Narrowing with type guards
+
+```ts
+const result = findUser(id)
+
+if (result.isRight()) {
+  console.log(result.value.name) // typed as User
+}
+
+if (result.isError()) {
+  console.log(result.value) // typed as string
+}
+```
+
+---
+
+## Async chains
+
+Transition to `AsyncEither` via `transformAsync` or `andThenAsync`, then keep chaining:
+
+```ts
+import { right } from 'failcraft'
+
+right(userId)
+  .transformAsync(async (id) => fetchUser(id))     // AsyncEither<never, User>
+  .andThen((user) => validateRole(user))           // sync step mid-chain
+  .andThenAsync(async (user) => saveAuditLog(user))
+  .match({
+    left: (err) => Response.error(err),
+    right: (user) => Response.json(user),
+  })
+  // Promise<Response>
+```
+
+---
+
+## Wrapping third-party code
+
+Use `trySync` / `tryAsync` at the boundary — never inside domain logic.
+
+```ts
+import { trySync, tryAsync } from 'failcraft'
+
+// Sync — always wrap in () =>
+const parsed = trySync(() => JSON.parse(raw))
+// Either<unknown, unknown>
+
+// Async
+const data = tryAsync(() => fetch(url).then(r => r.json()))
+// AsyncEither<unknown, unknown>
+
+// Common: cast the error type
+const result = trySync<ValidationError, Config>(() => parseConfig(raw))
+```
+
+---
+
+## Unwrapping
+
+```ts
+// Provide a fallback
+const name = findUser(id).orDefault(guestUser).name
+
+// Throw if you're certain it's right (e.g. in tests)
+const user = findUser(id).getOrThrow()
+
+// Throw a custom error
+const user = findUser(id).getOrThrowWith((err) => new NotFoundError(err))
+```
+
+---
+
+## Composing multiple Eithers
+
+```ts
+function createOrder(userId: string, productId: string): Either<string, Order> {
+  return findUser(userId)
+    .andThen((user) => findProduct(productId).transform((product) => ({ user, product })))
+    .andThen(({ user, product }) => buildOrder(user, product))
+}
+```


### PR DESCRIPTION
## Summary

- Add `skills/use-failcraft/SKILL.md` — main skill with trigger description, critical rules, and usage overview for `Either`, `AsyncEither`, and try helpers
- Add `skills/use-failcraft/references/api.md` — full type signatures and method table for all public exports
- Add `skills/use-failcraft/references/patterns.md` — real-world patterns: chaining, async, match, narrowing, wrapping third-party code

## Test plan

- [ ] Install skill and verify it triggers on "Either", "left", "right", "trySync", "tryAsync", "failcraft"
- [ ] Confirm API reference matches exported types in `src/index.ts`
- [ ] Confirm patterns match actual runtime behavior