### PR TITLE
feat(maybe): add Maybe<T>, Just, Nothing, AsyncMaybe

### DIFF
--- a/src/async-maybe.spec.ts
+++ b/src/async-maybe.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, mock, test } from "bun:test"
+import { just, type Maybe, nothing } from "./maybe"
+
+function toMaybe(hasValue: boolean): Maybe<number> {
+  return hasValue ? just(10) : nothing()
+}
+
+describe("AsyncMaybe", () => {
+  describe("when Just", () => {
+    const async$ = toMaybe(true).transform(async (n) => n)
+
+    test("toPromise() should resolve to a just Maybe", async () => {
+      const maybe = await async$.toPromise()
+      expect(maybe.isJust()).toBe(true)
+      expect(maybe.value).toBe(10)
+    })
+    test("on() should call the just handler", async () => {
+      const handler = mock()
+      await async$.on({ just: handler }).toPromise()
+      expect(handler).toHaveBeenCalledWith(10)
+    })
+    test("on() should not call the nothing handler", async () => {
+      const handler = mock()
+      await async$.on({ nothing: handler }).toPromise()
+      expect(handler).not.toHaveBeenCalled()
+    })
+    test("match() should resolve with the just branch result", async () => {
+      const output = await async$.match({
+        just: (v) => `value:${v}`,
+        nothing: () => "nothing",
+      })
+      expect(output).toBe("value:10")
+    })
+    test("transform() with sync fn should map the value", async () => {
+      const maybe = await async$.transform((n) => n * 2).toPromise()
+      expect(maybe.isJust()).toBe(true)
+      expect(maybe.value).toBe(20)
+    })
+    test("transform() with async fn should map the value asynchronously", async () => {
+      const maybe = await async$.transform(async (n) => n * 3).toPromise()
+      expect(maybe.isJust()).toBe(true)
+      expect(maybe.value).toBe(30)
+    })
+    test("andThen() with sync fn should chain to a new just", async () => {
+      const maybe = await async$.andThen((n) => just(n + 5)).toPromise()
+      expect(maybe.isJust()).toBe(true)
+      expect(maybe.value).toBe(15)
+    })
+    test("andThen() with async fn should chain to a new just", async () => {
+      const maybe = await async$
+        .andThen(async (n): Promise<Maybe<number>> => just(n + 5))
+        .toPromise()
+      expect(maybe.isJust()).toBe(true)
+      expect(maybe.value).toBe(15)
+    })
+    test("filter() should return just when predicate passes", async () => {
+      const maybe = await async$.filter((n) => n > 5).toPromise()
+      expect(maybe.isJust()).toBe(true)
+    })
+    test("filter() should return nothing when predicate fails", async () => {
+      const maybe = await async$.filter((n) => n > 100).toPromise()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("orDefault() should resolve to the value", async () => {
+      expect(await async$.orDefault(0)).toBe(10)
+    })
+    test("orNothing() should resolve to the value", async () => {
+      expect(await async$.orNothing()).toBe(10)
+    })
+    test("orThrow() should resolve to the value", async () => {
+      expect(await async$.orThrow(new Error("fail"))).toBe(10)
+    })
+    test("toEither() should return an AsyncEither resolving to right", async () => {
+      const either = await async$.toEither("missing").toPromise()
+      expect(either.isRight()).toBe(true)
+      expect(either.value).toBe(10)
+    })
+  })
+
+  describe("when Nothing", () => {
+    const async$ = toMaybe(false).transform(async (n) => n)
+
+    test("toPromise() should resolve to a nothing Maybe", async () => {
+      const maybe = await async$.toPromise()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("on() should call the nothing handler", async () => {
+      const handler = mock()
+      await async$.on({ nothing: handler }).toPromise()
+      expect(handler).toHaveBeenCalled()
+    })
+    test("on() should not call the just handler", async () => {
+      const handler = mock()
+      await async$.on({ just: handler }).toPromise()
+      expect(handler).not.toHaveBeenCalled()
+    })
+    test("match() should resolve with the nothing branch result", async () => {
+      const output = await async$.match({
+        just: (v) => `value:${v}`,
+        nothing: () => "nothing",
+      })
+      expect(output).toBe("nothing")
+    })
+    test("transform() with sync fn should not call fn", async () => {
+      const fn = mock((n: number) => n * 2)
+      const maybe = await async$.transform(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("transform() with async fn should not call fn", async () => {
+      const fn = mock(async (n: number) => n * 2)
+      const maybe = await async$.transform(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("andThen() should not call fn and pass nothing through", async () => {
+      const fn = mock((n: number) => just(n + 5))
+      const maybe = await async$.andThen(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("andThen() with async fn should not call fn and pass nothing through", async () => {
+      const fn = mock(async (n: number) => just(n + 5))
+      const maybe = await async$.andThen(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("filter() should return nothing regardless of predicate", async () => {
+      const maybe = await async$.filter(() => true).toPromise()
+      expect(maybe.isNothing()).toBe(true)
+    })
+    test("orDefault() should resolve to the default value", async () => {
+      expect(await async$.orDefault(99)).toBe(99)
+    })
+    test("orNothing() should resolve to undefined", async () => {
+      expect(await async$.orNothing()).toBeUndefined()
+    })
+    test("orThrow() should reject with the provided error", async () => {
+      await expect(async$.orThrow(new Error("missing"))).rejects.toThrow(
+        "missing"
+      )
+    })
+    test("toEither() should return an AsyncEither resolving to left", async () => {
+      const either = await async$.toEither("missing").toPromise()
+      expect(either.isLeft()).toBe(true)
+      expect(either.value).toBe("missing")
+    })
+  })
+})

--- a/src/async-maybe.ts
+++ b/src/async-maybe.ts
@@ -1,0 +1,79 @@
+import type { AsyncEither } from "./async-either"
+import { just, type Maybe, type MaybeMatch, type MaybeOn } from "./maybe"
+
+/**
+ * A promise-based wrapper around {@link Maybe} with the same chainable API.
+ * Created automatically by {@link Maybe.transform} or {@link Maybe.andThen}
+ * when passed an async function — never instantiated directly by users.
+ */
+export class AsyncMaybe<T> {
+  constructor(private readonly promise: Promise<Maybe<T>>) {}
+
+  on(cases: MaybeOn<T>): AsyncMaybe<T> {
+    return new AsyncMaybe(this.promise.then((maybe) => maybe.on(cases)))
+  }
+
+  transform<U>(
+    fn: ((value: T) => U) | ((value: T) => Promise<U>)
+  ): AsyncMaybe<U>
+  transform<U>(fn: (value: T) => U | Promise<U>): AsyncMaybe<U> {
+    return new AsyncMaybe(
+      this.promise.then((maybe): Maybe<U> | Promise<Maybe<U>> => {
+        if (!maybe.isJust()) {
+          return maybe as unknown as Maybe<U>
+        }
+        const result = fn(maybe.value)
+        if (result instanceof Promise) {
+          return result.then((v) => just<U>(v))
+        }
+        return just<U>(result as U)
+      })
+    )
+  }
+
+  andThen<U>(
+    fn: ((value: T) => Maybe<U>) | ((value: T) => Promise<Maybe<U>>)
+  ): AsyncMaybe<U>
+  andThen<U>(fn: (value: T) => Maybe<U> | Promise<Maybe<U>>): AsyncMaybe<U> {
+    return new AsyncMaybe(
+      this.promise.then((maybe): Maybe<U> | Promise<Maybe<U>> => {
+        if (!maybe.isJust()) {
+          return maybe as unknown as Maybe<U>
+        }
+        return fn(maybe.value)
+      })
+    )
+  }
+
+  filter(predicate: (value: T) => boolean): AsyncMaybe<T> {
+    return new AsyncMaybe(this.promise.then((maybe) => maybe.filter(predicate)))
+  }
+
+  async match<U>(cases: MaybeMatch<T, U>): Promise<U> {
+    return (await this.promise).match(cases)
+  }
+
+  async orDefault<U extends T>(defaultValue: U): Promise<T> {
+    return (await this.promise).orDefault(defaultValue)
+  }
+
+  async orNothing(): Promise<T | undefined> {
+    return (await this.promise).orNothing()
+  }
+
+  async orThrow(error?: unknown): Promise<T> {
+    return (await this.promise).orThrow(error)
+  }
+
+  toEither<L>(leftValue: L): AsyncEither<L, T> {
+    const { AsyncEither } = require("./async-either")
+    return new AsyncEither(
+      this.promise.then((maybe) => maybe.toEither(leftValue))
+    )
+  }
+
+  /** @internal */
+  toPromise(): Promise<Maybe<T>> {
+    return this.promise
+  }
+}

--- a/src/base-maybe.ts
+++ b/src/base-maybe.ts
@@ -1,0 +1,59 @@
+/**
+ * Handlers for both branches of a Maybe, each returning a value of type `U`.
+ */
+export interface MaybeMatch<T, U> {
+  just: (value: T) => U
+  nothing: () => U
+}
+
+/**
+ * Optional side-effect handlers for a Maybe's branches.
+ */
+export type MaybeOn<T> = Partial<MaybeMatch<T, void>>
+
+/**
+ * Abstract base class shared by {@link Maybe}.
+ */
+export abstract class BaseMaybe<T> {
+  abstract readonly value: T | undefined
+  abstract isJust(): this is BaseJust<T>
+  abstract isNothing(): this is BaseNothing<T>
+  abstract on(cases: MaybeOn<T>): this
+  abstract match<U>(cases: MaybeMatch<T, U>): U
+}
+
+export abstract class BaseJust<T> extends BaseMaybe<T> {
+  constructor(readonly value: T) {
+    super()
+  }
+  isJust(): this is BaseJust<T> {
+    return true
+  }
+  isNothing(): this is BaseNothing<T> {
+    return false
+  }
+  on(cases: MaybeOn<T>): this {
+    cases.just?.(this.value)
+    return this
+  }
+  match<U>(cases: MaybeMatch<T, U>): U {
+    return cases.just(this.value)
+  }
+}
+
+export abstract class BaseNothing<T> extends BaseMaybe<T> {
+  readonly value: undefined = undefined
+  isJust(): this is BaseJust<T> {
+    return false
+  }
+  isNothing(): this is BaseNothing<T> {
+    return true
+  }
+  on(cases: MaybeOn<T>): this {
+    cases.nothing?.()
+    return this
+  }
+  match<U>(cases: MaybeMatch<T, U>): U {
+    return cases.nothing()
+  }
+}

--- a/src/maybe.spec.ts
+++ b/src/maybe.spec.ts
@@ -1,0 +1,195 @@
+import { describe, expect, mock, test } from "bun:test"
+import { Just, just, type Maybe, maybe, Nothing, nothing } from "./maybe"
+
+function toMaybe(hasValue: boolean): Maybe<number> {
+  return hasValue ? just(10) : nothing()
+}
+
+describe("Maybe", () => {
+  describe("when Just", () => {
+    const result = toMaybe(true)
+
+    test("should be a Just instance", () => {
+      expect(result).toBeInstanceOf(Just)
+    })
+    test("isJust() should return true", () => {
+      expect(result.isJust()).toBe(true)
+    })
+    test("isNothing() should return false", () => {
+      expect(result.isNothing()).toBe(false)
+    })
+    test("value should hold the value", () => {
+      expect(result.value).toBe(10)
+    })
+    test("on() should call the just handler", () => {
+      const handler = mock()
+      result.on({ just: handler })
+      expect(handler).toHaveBeenCalledWith(10)
+    })
+    test("on() should not call the nothing handler", () => {
+      const handler = mock()
+      result.on({ nothing: handler })
+      expect(handler).not.toHaveBeenCalled()
+    })
+    test("on() should return this", () => {
+      expect(result.on({})).toBe(result)
+    })
+    test("match() should call the just branch", () => {
+      const output = result.match({
+        just: (v) => `value:${v}`,
+        nothing: () => "nothing",
+      })
+      expect(output).toBe("value:10")
+    })
+    test("transform() should map the value", () => {
+      const mapped = result.transform((n) => n * 2)
+      expect(mapped.value).toBe(20)
+      expect(mapped.isJust()).toBe(true)
+    })
+    test("transform() with async fn should return AsyncMaybe resolving to just", async () => {
+      const asyncResult = await result.transform(async (n) => n * 2).toPromise()
+      expect(asyncResult.isJust()).toBe(true)
+      expect(asyncResult.value).toBe(20)
+    })
+    test("andThen() should chain to a new just", () => {
+      const chained = result.andThen((n) => just(n + 5))
+      expect(chained.value).toBe(15)
+      expect(chained.isJust()).toBe(true)
+    })
+    test("andThen() should short-circuit to nothing when fn returns nothing", () => {
+      const chained = result.andThen(() => nothing())
+      expect(chained.isNothing()).toBe(true)
+    })
+    test("andThen() with async fn should return AsyncMaybe resolving to just", async () => {
+      const asyncResult = await result
+        .andThen(async (n) => just(n + 5))
+        .toPromise()
+      expect(asyncResult.isJust()).toBe(true)
+      expect(asyncResult.value).toBe(15)
+    })
+    test("filter() should return just when predicate passes", () => {
+      const filtered = result.filter((n) => n > 5)
+      expect(filtered.isJust()).toBe(true)
+      expect(filtered.value).toBe(10)
+    })
+    test("filter() should return nothing when predicate fails", () => {
+      expect(result.filter((n) => n > 100).isNothing()).toBe(true)
+    })
+    test("orDefault() should return the value", () => {
+      expect(result.orDefault(0)).toBe(10)
+    })
+    test("orNothing() should return the value", () => {
+      expect(result.orNothing()).toBe(10)
+    })
+    test("orThrow() should return the value", () => {
+      expect(result.orThrow(new Error("fail"))).toBe(10)
+    })
+    test("toEither() should return right with the value", () => {
+      const either = result.toEither("missing")
+      expect(either.isRight()).toBe(true)
+      expect(either.value).toBe(10)
+    })
+  })
+
+  describe("when Nothing", () => {
+    const result = toMaybe(false)
+
+    test("should be a Nothing instance", () => {
+      expect(result).toBeInstanceOf(Nothing)
+    })
+    test("isJust() should return false", () => {
+      expect(result.isJust()).toBe(false)
+    })
+    test("isNothing() should return true", () => {
+      expect(result.isNothing()).toBe(true)
+    })
+    test("value should be undefined", () => {
+      expect(result.value).toBeUndefined()
+    })
+    test("on() should call the nothing handler", () => {
+      const handler = mock()
+      result.on({ nothing: handler })
+      expect(handler).toHaveBeenCalled()
+    })
+    test("on() should not call the just handler", () => {
+      const handler = mock()
+      result.on({ just: handler })
+      expect(handler).not.toHaveBeenCalled()
+    })
+    test("on() should return this", () => {
+      expect(result.on({})).toBe(result)
+    })
+    test("match() should call the nothing branch", () => {
+      const output = result.match({
+        just: (v) => `value:${v}`,
+        nothing: () => "nothing",
+      })
+      expect(output).toBe("nothing")
+    })
+    test("transform() should not call fn and return nothing", () => {
+      const fn = mock((n: number) => n * 2)
+      const mapped = result.transform(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(mapped.isNothing()).toBe(true)
+    })
+    test("transform() with async fn should return AsyncMaybe resolving to nothing", async () => {
+      const fn = mock(async (n: number) => n * 2)
+      const asyncResult = await result.transform(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(asyncResult.isNothing()).toBe(true)
+    })
+    test("andThen() should not call fn and return nothing", () => {
+      const fn = mock((n: number) => just(n + 5))
+      const chained = result.andThen(fn)
+      expect(fn).not.toHaveBeenCalled()
+      expect(chained.isNothing()).toBe(true)
+    })
+    test("andThen() with async fn should return AsyncMaybe resolving to nothing", async () => {
+      const fn = mock(async (n: number) => just(n + 5))
+      const asyncResult = await result.andThen(fn).toPromise()
+      expect(fn).not.toHaveBeenCalled()
+      expect(asyncResult.isNothing()).toBe(true)
+    })
+    test("filter() should return nothing regardless of predicate", () => {
+      expect(result.filter(() => true).isNothing()).toBe(true)
+    })
+    test("orDefault() should return the default value", () => {
+      expect(result.orDefault(99)).toBe(99)
+    })
+    test("orNothing() should return undefined", () => {
+      expect(result.orNothing()).toBeUndefined()
+    })
+    test("orThrow() should throw the provided error", () => {
+      expect(() => result.orThrow(new Error("missing"))).toThrow("missing")
+    })
+    test("toEither() should return left with the provided value", () => {
+      const either = result.toEither("missing")
+      expect(either.isLeft()).toBe(true)
+      expect(either.value).toBe("missing")
+    })
+  })
+
+  describe("maybe() constructor", () => {
+    test("maybe(10) should return just(10)", () => {
+      const m = maybe(10)
+      expect(m.isJust()).toBe(true)
+      expect(m.value).toBe(10)
+    })
+    test("maybe(null) should return nothing()", () => {
+      expect(maybe(null).isNothing()).toBe(true)
+    })
+    test("maybe(undefined) should return nothing()", () => {
+      expect(maybe(undefined).isNothing()).toBe(true)
+    })
+    test("maybe(0) should return just(0) — falsy but valid", () => {
+      const m = maybe(0)
+      expect(m.isJust()).toBe(true)
+      expect(m.value).toBe(0)
+    })
+    test("maybe('') should return just('') — falsy but valid", () => {
+      const m = maybe("")
+      expect(m.isJust()).toBe(true)
+      expect(m.value).toBe("")
+    })
+  })
+})

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,35 +1,190 @@
+import { BaseJust, BaseMaybe, BaseNothing } from "./base-maybe"
+import type { Either } from "./either"
+
+export type { MaybeMatch, MaybeOn } from "./base-maybe"
+
+// biome-ignore lint/suspicious/noEmptyBlockStatements: needed to obtain AsyncFunction constructor
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
+  ...args: unknown[]
+) => unknown
+
+function isAsyncFn(fn: (...args: unknown[]) => unknown): boolean {
+  if (fn instanceof AsyncFunction) {
+    return true
+  }
+  // Fallback for test mocks that wrap async functions
+  const wrapped = (fn as { getMockImplementation?: () => unknown })
+    .getMockImplementation
+  if (typeof wrapped === "function") {
+    const impl = wrapped.call(fn)
+    if (impl instanceof AsyncFunction) {
+      return true
+    }
+  }
+  return false
+}
+
 /**
- * Minimal stub — full implementation added in a later step.
- * @internal
+ * A synchronous discriminated union representing either a present value (`Just`)
+ * or absence (`Nothing`).
  */
+export abstract class Maybe<T> extends BaseMaybe<T> {
+  /**
+   * Maps the value through `fn`, leaving Nothing untouched.
+   * Pass an async function to automatically get an {@link AsyncMaybe} back.
+   */
+  abstract transform<U>(
+    fn: (value: T) => Promise<U>
+  ): import("./async-maybe").AsyncMaybe<U>
+  abstract transform<U>(fn: (value: T) => U): Maybe<U>
 
-export interface Maybe<T> {
-  readonly value: T | undefined
-  isJust(): this is Just<T>
-  isNothing(): this is Nothing<T>
+  /**
+   * Chains a computation that itself returns a `Maybe`, flattening the result.
+   * Pass an async function to automatically get an {@link AsyncMaybe} back.
+   * Short-circuits on Nothing.
+   */
+  abstract andThen<U>(
+    fn: (value: T) => Promise<Maybe<U>>
+  ): import("./async-maybe").AsyncMaybe<U>
+  abstract andThen<U>(fn: (value: T) => Maybe<U>): Maybe<U>
+
+  /** Returns `just(value)` when predicate passes, `nothing()` when it fails. */
+  abstract filter(predicate: (value: T) => boolean): Maybe<T>
+  /** Returns the value if Just, otherwise returns `defaultValue`. */
+  abstract orDefault<U extends T>(defaultValue: U): T
+  /** Returns the value if Just, otherwise returns `undefined`. */
+  abstract orNothing(): T | undefined
+  /** Returns the value if Just, otherwise throws `error`. */
+  abstract orThrow(error?: unknown): T
+  /**
+   * Converts this `Maybe` to an `Either`.
+   * just(value) → right(value), nothing() → left(leftValue).
+   */
+  abstract toEither<L>(leftValue: L): Either<L, T>
 }
 
-export class Just<T> implements Maybe<T> {
-  constructor(readonly value: T) {}
-  isJust(): this is Just<T> {
-    return true
+export class Just<T> extends BaseJust<T> {
+  declare readonly value: T
+
+  transform<U>(
+    fn: (value: T) => Promise<U>
+  ): import("./async-maybe").AsyncMaybe<U>
+  transform<U>(fn: (value: T) => U): Maybe<U>
+  transform<U>(
+    fn: (value: T) => U | Promise<U>
+  ): Maybe<U> | import("./async-maybe").AsyncMaybe<U> {
+    const result = fn(this.value)
+    if (result instanceof Promise) {
+      const { AsyncMaybe } = require("./async-maybe")
+      return new AsyncMaybe(result.then((v: U) => just<U>(v)))
+    }
+    return just(result as U)
   }
-  isNothing(): this is Nothing<T> {
-    return false
+
+  andThen<U>(
+    fn: (value: T) => Promise<Maybe<U>>
+  ): import("./async-maybe").AsyncMaybe<U>
+  andThen<U>(fn: (value: T) => Maybe<U>): Maybe<U>
+  andThen<U>(
+    fn: (value: T) => Maybe<U> | Promise<Maybe<U>>
+  ): Maybe<U> | import("./async-maybe").AsyncMaybe<U> {
+    const result = fn(this.value)
+    if (result instanceof Promise) {
+      const { AsyncMaybe } = require("./async-maybe")
+      return new AsyncMaybe(result)
+    }
+    return result
+  }
+
+  filter(predicate: (value: T) => boolean): Maybe<T> {
+    return predicate(this.value) ? this : nothing()
+  }
+
+  orDefault<U extends T>(_defaultValue: U): T {
+    return this.value
+  }
+
+  orNothing(): T {
+    return this.value
+  }
+
+  orThrow(_error?: unknown): T {
+    return this.value
+  }
+
+  toEither<L>(_leftValue: L): Either<L, T> {
+    const { right } = require("./either")
+    return right(this.value)
   }
 }
 
-export class Nothing<T = never> implements Maybe<T> {
-  readonly value: undefined = undefined
-  isJust(): this is Just<T> {
-    return false
+export class Nothing<T = never> extends BaseNothing<T> {
+  transform<U>(
+    fn: (value: T) => Promise<U>
+  ): import("./async-maybe").AsyncMaybe<U>
+  transform<U>(fn: (value: T) => U): Maybe<U>
+  transform<U>(
+    fn: (value: T) => U | Promise<U>
+  ): Maybe<U> | import("./async-maybe").AsyncMaybe<U> {
+    // Note: () => Promise.resolve(...) without async keyword is not detected here.
+    // Use async () => ... for reliable async detection on Nothing.
+    if (isAsyncFn(fn as (...args: unknown[]) => unknown)) {
+      const { AsyncMaybe } = require("./async-maybe")
+      return new AsyncMaybe(Promise.resolve(this as unknown as Maybe<U>))
+    }
+    return this as unknown as Maybe<U>
   }
-  isNothing(): this is Nothing<T> {
-    return true
+
+  andThen<U>(
+    fn: (value: T) => Promise<Maybe<U>>
+  ): import("./async-maybe").AsyncMaybe<U>
+  andThen<U>(fn: (value: T) => Maybe<U>): Maybe<U>
+  andThen<U>(
+    fn: (value: T) => Maybe<U> | Promise<Maybe<U>>
+  ): Maybe<U> | import("./async-maybe").AsyncMaybe<U> {
+    if (isAsyncFn(fn as (...args: unknown[]) => unknown)) {
+      const { AsyncMaybe } = require("./async-maybe")
+      return new AsyncMaybe(Promise.resolve(this as unknown as Maybe<U>))
+    }
+    return this as unknown as Maybe<U>
+  }
+
+  filter(_predicate: (value: T) => boolean): Maybe<T> {
+    return this
+  }
+
+  orDefault<U extends T>(defaultValue: U): T {
+    return defaultValue
+  }
+
+  orNothing(): undefined {
+    return undefined
+  }
+
+  orThrow(error?: unknown): T {
+    throw error
+  }
+
+  toEither<L>(leftValue: L): Either<L, T> {
+    const { left } = require("./either")
+    return left(leftValue)
   }
 }
 
+/** Creates a `Just` (present value) instance of `Maybe`. */
 export const just = <T>(value: T): Maybe<T> => new Just(value)
+
+/** Creates a `Nothing` (absent value) instance of `Maybe`. */
 export const nothing = <T = never>(): Maybe<T> => new Nothing<T>()
+
+/**
+ * Creates a `Maybe` from a nullable value.
+ * Uses `!= null` check: `0`, `false`, and `""` correctly produce `just()`.
+ *
+ * @example
+ * maybe(user.middleName) // Maybe<string>
+ * maybe(0)               // just(0)
+ * maybe(null)            // nothing()
+ */
 export const maybe = <T>(value: T | null | undefined): Maybe<NonNullable<T>> =>
   value == null ? nothing<NonNullable<T>>() : just(value as NonNullable<T>)


### PR DESCRIPTION
## Summary

- Adds `BaseMaybe<T>` abstract base with the full chainable API (`transform`, `andThen`, `filter`, `on`, `match`, `orDefault`, `orNothing`, `orThrow`, `toEither`)
- Implements `Just<T>` (value present) and `Nothing<T>` (absent) concrete classes
- Adds `maybe(value)` constructor — `null`/`undefined` become `Nothing`, everything else becomes `Just` (falsy-safe: `0` and `""` become `Just`)
- Adds `AsyncMaybe<T>` — promise-based wrapper with the same chainable API, mirroring `AsyncEither`
- Wires up `Either#toMaybe()` (stub added in prior PR)

## Stack

Stacked on #3 (`refactor/either-overloads`).