### PR TITLE
chore: release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failcraft",
   "description": "",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Bumps version to 1.2.0 and publishes to npm.

See [#11](https://github.com/joao-coimbra/failcraft/pull/11) for the full changelog.