### PR TITLE
docs: add missing JSDoc to AsyncMaybe, AsyncEither, Result, and try helpers

### DIFF
--- a/src/async-either.ts
+++ b/src/async-either.ts
@@ -4,8 +4,10 @@ import { type Either, type EitherMatch, type EitherOn, right } from "./either"
  * A promise-based wrapper around {@link Either} that keeps the same chainable
  * API without requiring `await` at every step.
  *
- * Instances are created automatically by {@link tryAsync}, and can be awaited
- * via {@link AsyncEither.toPromise}.
+ * Created automatically when an async function is passed to `transform` or
+ * `andThen`, or when using {@link attempt} with an async function.
+ * Use {@link from} as the explicit entry point when wrapping an existing
+ * `Promise<Either>`.
  *
  * @typeParam L - The left (error) type.
  * @typeParam R - The right (success) type.

--- a/src/async-maybe.ts
+++ b/src/async-maybe.ts
@@ -3,16 +3,30 @@ import { just, type Maybe, type MaybeMatch, type MaybeOn } from "./maybe"
 
 /**
  * A promise-based wrapper around {@link Maybe} with the same chainable API.
+ *
  * Created automatically by {@link Maybe.transform} or {@link Maybe.andThen}
  * when passed an async function — never instantiated directly by users.
+ *
+ * @typeParam T - The type of the present value.
  */
 export class AsyncMaybe<T> {
   constructor(private readonly promise: Promise<Maybe<T>>) {}
 
+  /**
+   * Runs the matching side-effect handler for whichever branch resolves,
+   * then passes the `Maybe` through unchanged.
+   *
+   * @param cases - Partial handlers; omit a branch to ignore it.
+   */
   on(cases: MaybeOn<T>): AsyncMaybe<T> {
     return new AsyncMaybe(this.promise.then((maybe) => maybe.on(cases)))
   }
 
+  /**
+   * Maps the value through `fn` once the promise resolves.
+   * Accepts both sync and async functions; always returns `AsyncMaybe`.
+   * Short-circuits on Nothing.
+   */
   transform<U>(
     fn: ((value: T) => U) | ((value: T) => Promise<U>)
   ): AsyncMaybe<U>
@@ -31,6 +45,11 @@ export class AsyncMaybe<T> {
     )
   }
 
+  /**
+   * Chains a computation returning a `Maybe`, flattening the result.
+   * Accepts both sync and async functions; always returns `AsyncMaybe`.
+   * Short-circuits on Nothing.
+   */
   andThen<U>(
     fn: ((value: T) => Maybe<U>) | ((value: T) => Promise<Maybe<U>>)
   ): AsyncMaybe<U>
@@ -45,26 +64,57 @@ export class AsyncMaybe<T> {
     )
   }
 
+  /**
+   * Resolves to `just(value)` when predicate passes, `nothing()` when it fails.
+   *
+   * @param predicate - Test applied to the present value.
+   */
   filter(predicate: (value: T) => boolean): AsyncMaybe<T> {
     return new AsyncMaybe(this.promise.then((maybe) => maybe.filter(predicate)))
   }
 
+  /**
+   * Exhaustively pattern-matches the resolved Maybe, returning a `Promise`
+   * of the handler's result.
+   *
+   * @param cases - Both `just` and `nothing` handlers must be provided.
+   */
   async match<U>(cases: MaybeMatch<T, U>): Promise<U> {
     return (await this.promise).match(cases)
   }
 
+  /**
+   * Resolves to the present value, or `defaultValue` if Nothing.
+   *
+   * @param defaultValue - Fallback value, must be assignable to `T`.
+   */
   async orDefault<U extends T>(defaultValue: U): Promise<T> {
     return (await this.promise).orDefault(defaultValue)
   }
 
+  /**
+   * Resolves to the present value, or `undefined` if Nothing.
+   */
   async orNothing(): Promise<T | undefined> {
     return (await this.promise).orNothing()
   }
 
+  /**
+   * Resolves to the present value, or throws `error` if Nothing.
+   *
+   * @param error - Value to throw when Nothing. Defaults to `undefined`.
+   * @throws The provided `error`.
+   */
   async orThrow(error?: unknown): Promise<T> {
     return (await this.promise).orThrow(error)
   }
 
+  /**
+   * Converts the resolved `Maybe` to an `AsyncEither`.
+   * `just(value)` → `right(value)`, `nothing()` → `left(leftValue)`.
+   *
+   * @param leftValue - Value to use as the left (error) side when Nothing.
+   */
   toEither<L>(leftValue: L): AsyncEither<L, T> {
     return new AsyncEither(
       this.promise.then((maybe) => maybe.toEither(leftValue))

--- a/src/result.ts
+++ b/src/result.ts
@@ -16,10 +16,22 @@ import { left, right } from "./either"
  */
 export type Result<T, E = Error> = Either<E, T>
 
-/** Creates a successful `Result` (maps to `right`). */
+/**
+ * Creates a successful `Result` (wraps a value as `right`).
+ *
+ * @example
+ * ok(user)        // Result<User, never>
+ * ok(user) satisfies Result<User, "not_found">
+ */
 export const ok = <const T, E = Error>(value: T): Result<T, E> =>
   right<T, E>(value)
 
-/** Creates a failed `Result` (maps to `left`). */
+/**
+ * Creates a failed `Result` (wraps an error as `left`).
+ *
+ * @example
+ * err("not_found")   // Result<never, "not_found">
+ * err(new Error("unexpected"))  // Result<never, Error>
+ */
 export const err = <const E, T = never>(error: E): Result<T, E> =>
   left<E, T>(error)

--- a/src/try.ts
+++ b/src/try.ts
@@ -3,15 +3,14 @@ import { type Either, left, right } from "./either"
 /**
  * Wraps a synchronous function in an `Either`, catching any thrown error as a left.
  *
+ * @deprecated Use {@link attempt} instead — it handles both sync and async in a single call.
+ *
  * @param fn - A function that may throw.
  * @returns `right(result)` on success, `left(error)` on throw.
  *
  * @example
  * const result = trySync(() => JSON.parse(raw))
  * // Either<unknown, ParsedType>
- */
-/**
- * @deprecated Use {@link attempt} instead — it handles both sync and async in a single call.
  */
 export const trySync = <L = unknown, R = unknown>(
   fn: () => R
@@ -26,15 +25,14 @@ export const trySync = <L = unknown, R = unknown>(
 /**
  * Wraps an async function in a `Promise<Either>`, catching any rejection as a left.
  *
+ * @deprecated Use {@link attempt} instead — it handles both sync and async in a single call.
+ *
  * @param fn - An async function that may reject.
  * @returns A `Promise` that resolves to `right(result)` or `left(error)`.
  *
  * @example
  * const result = await tryAsync(() => fetch("/api/data").then(r => r.json()))
  * // Either<unknown, Data>
- */
-/**
- * @deprecated Use {@link attempt} instead — it handles both sync and async in a single call.
  */
 export const tryAsync = <L = unknown, R = unknown>(
   fn: () => Promise<R>


### PR DESCRIPTION
## Summary

- `AsyncMaybe` — added JSDoc to all public methods (`on`, `transform`, `andThen`, `filter`, `match`, `orDefault`, `orNothing`, `orThrow`, `toEither`) matching the `AsyncEither` documentation style
- `AsyncEither` — updated class doc to reference `attempt` alongside `transform`/`andThen`
- `Result` — expanded `ok()` and `err()` JSDoc with `@example` tags
- `try.ts` — merged the duplicate `/** */` blocks into one per function (`@deprecated` now lives inside the main description block)