### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failcraft",
   "description": "",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Bumps version to 1.3.0 and publishes to npm.