### PR TITLE
chore: release v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failcraft",
   "description": "",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Bumps version to 1.3.1 (republish of 1.3.0 — tarball upload failure on first attempt).