### PR TITLE
docs: update README, CLAUDE.md and package.json for v1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,12 +196,14 @@ src/
 ├── index.ts          # Public re-exports for everything below
 ├── base-either.ts    # Abstract base classes (BaseEither, BaseLeft, BaseRight) and shared interfaces (EitherMatch, EitherOn)
 ├── either.ts         # Either<L,R>, Left, Right — sync Either with overloaded transform/andThen/toMaybe; left() and right() constructors
-├── async-either.ts   # AsyncEither<L,R> — promise-based Either wrapper with the same chainable API; from() constructor
+├── async-either.ts   # AsyncEither<L,R> — promise-based Either wrapper with the same chainable API
+├── from.ts           # from() — overloaded entry point: Promise<Either> → AsyncEither, Promise<Maybe> → AsyncMaybe
 ├── base-maybe.ts     # Abstract base classes (BaseMaybe, BaseJust, BaseNothing) and shared interfaces (MaybeMatch, MaybeOn)
 ├── maybe.ts          # Maybe<T>, Just<T>, Nothing — sync Maybe with overloaded transform/andThen/filter/toEither; maybe(), just(), nothing() constructors
 ├── async-maybe.ts    # AsyncMaybe<T> — promise-based Maybe wrapper with the same chainable API
 ├── result.ts         # Result<T,E> type alias over Either<E,T>; ok() and err() constructors
-└── try.ts            # trySync() / tryAsync() — safe wrappers around try/catch that return Either / Promise<Either>
+├── attempt.ts        # attempt(fn, mapError?) — unified try/catch wrapper; auto-detects sync/async; returns Either or AsyncEither
+└── try.ts            # trySync() / tryAsync() — simple try/catch wrappers returning Either / Promise<Either>
 ```
 
 Test files are co-located with source as `*.spec.ts`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <br />
 
-[Install](#install) · [Either](#either) · [Chaining](#chaining) · [Async](#async) · [Maybe](#maybe) · [Result](#result) · [Try helpers](#try-helpers) · [API](#api)
+[Install](#install) · [Either](#either) · [Chaining](#chaining) · [Async](#async) · [Maybe](#maybe) · [Result](#result) · [Try helpers](#try-helpers) · [Attempt](#attempt) · [API](#api)
 
 <br />
 
@@ -237,6 +237,31 @@ data
 
 ---
 
+## Attempt
+
+`attempt()` is a unified try/catch wrapper that automatically detects whether the function is sync or async, and accepts an optional `mapError` to transform the caught value:
+
+```ts
+import { attempt } from 'failcraft'
+
+// Sync — returns Either<unknown, unknown>
+const parsed = attempt(() => JSON.parse(rawJson))
+
+// Async — returns AsyncEither<unknown, Data>
+const data = await attempt(async () => fetch("/api/data").then(r => r.json()))
+
+// With error mapping — narrow the left type
+const user = await attempt(
+  () => db.users.findOne(id),
+  (err) => err instanceof DatabaseError ? err.code : "UNKNOWN"
+)
+// AsyncEither<string, User>
+```
+
+Use `attempt()` when you want a single import that handles both sync and async throws with optional error shaping. Use `trySync`/`tryAsync` for simpler cases where you don't need error mapping.
+
+---
+
 ## API
 
 ### `left(value)` / `right(value)`
@@ -268,7 +293,7 @@ Same interface as `Either` but every method returns `AsyncEither` or `Promise`. 
 
 ### `from(promise)`
 
-Wraps a `Promise<Either<L, R>>` into a chainable `AsyncEither<L, R>`. Use this as the entry point whenever you have a `Promise<Either>` from an `async` function or `tryAsync` and want to continue chaining without intermediate `await` calls. The `await` goes once at the very end on the terminator (`orDefault`, `getOrThrow`, `match`).
+Wraps a `Promise<Either<L, R>>` into a chainable `AsyncEither<L, R>`, or a `Promise<Maybe<T>>` into a chainable `AsyncMaybe<T>`. Use this as the entry point whenever you have a `Promise<Either>` or `Promise<Maybe>` from an `async` function and want to keep chaining without intermediate `await` calls. The `await` goes once at the very end on the terminator (`orDefault`, `getOrThrow`, `match`).
 
 ### `Maybe<T>`
 
@@ -304,6 +329,10 @@ Type alias: `Result<T, E>` ≡ `Either<E, T>`. Use with `ok(value)` / `err(error
 ### `trySync(fn)` / `tryAsync(fn)`
 
 Wrap a possibly-throwing function. `trySync` returns `Either`, `tryAsync` returns `Promise<Either>`.
+
+### `attempt(fn, mapError?)`
+
+Unified try/catch wrapper that auto-detects sync vs async from the function signature. Returns `Either<L, R>` for sync functions and `AsyncEither<L, R>` for async ones. The optional `mapError` transforms the caught `unknown` error into the left type `L`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failcraft",
-  "description": "",
+  "description": "Functional error handling for TypeScript — type-safe Either, Maybe, and Result with composable async chains.",
   "version": "1.3.3",
   "type": "module",
   "private": false,


### PR DESCRIPTION
Updates documentation and metadata ahead of the v1.4.0 release.

- Add `## Attempt` section to README covering `attempt(fn, mapError?)`
- Update `from()` API docs to mention the `Promise<Maybe<T>>` → `AsyncMaybe<T>` overload
- Add `attempt()` nav link and API table entry
- Update `package.json` description field
- Sync CLAUDE.md architecture with `from.ts` and `attempt.ts`