### PR TITLE
fix(maybe): make isNothing() concrete to survive type bundling

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -48,7 +48,9 @@ export abstract class Maybe<T> {
     return this.isJust()
   }
 
-  abstract isNothing(): this is Nothing
+  isNothing(): this is Nothing {
+    return !this.isJust()
+  }
 
   abstract on(cases: MaybeOn<T>): this
 
@@ -91,10 +93,6 @@ export class Just<T> extends Maybe<T> {
 
   isJust(): this is Just<T> {
     return true
-  }
-
-  isNothing(): this is Nothing {
-    return false
   }
 
   on(cases: MaybeOn<T>): this {
@@ -154,10 +152,6 @@ export class Nothing extends Maybe<never> {
 
   isJust(): this is Just<never> {
     return false
-  }
-
-  isNothing(): this is Nothing {
-    return true
   }
 
   on(cases: MaybeOn<never>): this {


### PR DESCRIPTION
`rollup-plugin-dts` (used by bunup) silently drops abstract type predicates when the predicate type has no generic parameter. `isNothing(): this is Nothing` was being dropped from the published `.d.ts` while `isJust(): this is Just<T>` was kept, because `Nothing` carries no type parameter whereas `Just<T>` does.

Fix: convert `isNothing()` to a concrete method on `Maybe<T>` that delegates to `!this.isJust()`, matching the same pattern already used by `hasValue()`. `Just` and `Nothing` still override it with their own implementations, so runtime behavior and type narrowing are unchanged.