### PR TITLE
chore: release v1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failcraft",
   "description": "Functional error handling for TypeScript — type-safe Either, Maybe, and Result with composable async chains.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Patch release fixing isNothing() missing from published types.