### PR TITLE
fix(maybe,either): consolidate on() into base class, fix missing type in dist

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -73,7 +73,14 @@ export abstract class Either<L, R> {
    *
    * @param cases - Partial handlers; omit a branch to ignore it.
    */
-  abstract on(cases: EitherOn<L, R>): this
+  on(cases: EitherOn<L, R>): this {
+    if (this.isLeft()) {
+      cases.left?.(this.value as L)
+    } else {
+      cases.right?.(this.value as R)
+    }
+    return this
+  }
 
   /**
    * Exhaustively pattern-matches this Either, returning the result of
@@ -146,11 +153,6 @@ export class Left<L, R = never> extends Either<L, R> {
     return false
   }
 
-  on(cases: EitherOn<L, R>): this {
-    cases.left?.(this.value)
-    return this
-  }
-
   match<T>(cases: EitherMatch<L, R, T>): T {
     return cases.left(this.value)
   }
@@ -205,11 +207,6 @@ export class Right<R, L = never> extends Either<L, R> {
 
   isRight(): this is Right<R, L> {
     return true
-  }
-
-  on(cases: EitherOn<L, R>): this {
-    cases.right?.(this.value)
-    return this
   }
 
   match<T>(cases: EitherMatch<L, R, T>): T {

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -52,7 +52,14 @@ export abstract class Maybe<T> {
     return !this.isJust()
   }
 
-  abstract on(cases: MaybeOn<T>): this
+  on(cases: MaybeOn<T>): this {
+    if (this.isJust()) {
+      cases.just?.(this.value)
+    } else {
+      cases.nothing?.()
+    }
+    return this
+  }
 
   abstract match<U>(cases: MaybeMatch<T, U>): U
 
@@ -93,11 +100,6 @@ export class Just<T> extends Maybe<T> {
 
   isJust(): this is Just<T> {
     return true
-  }
-
-  on(cases: MaybeOn<T>): this {
-    cases.just?.(this.value)
-    return this
   }
 
   match<U>(cases: MaybeMatch<T, U>): U {
@@ -152,11 +154,6 @@ export class Nothing extends Maybe<never> {
 
   isJust(): this is Just<never> {
     return false
-  }
-
-  on(cases: MaybeOn<never>): this {
-    cases.nothing?.()
-    return this
   }
 
   match<U>(cases: MaybeMatch<never, U>): U {


### PR DESCRIPTION
`rollup-plugin-dts` drops `abstract` methods whose return type is `this`, causing `on()` to disappear from the published `.d.ts` on both `Maybe<T>` and `Either<L,R>`.

Fix: implement `on()` directly on the base classes using `isJust()`/`isLeft()` dispatch, removing the now-redundant overrides from `Just`, `Nothing`, `Left`, and `Right`. Runtime behavior is identical; the method is now concrete and survives bundling.