### PR TITLE
chore: release v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failcraft",
   "description": "Functional error handling for TypeScript — type-safe Either, Maybe, and Result with composable async chains.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "private": false,
   "files": [


### PR DESCRIPTION
Patch fixing on() missing from published types.