### PR TITLE
fix(maybe,either): consolidate match() into base class, fix missing type in dist

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -88,7 +88,12 @@ export abstract class Either<L, R> {
    *
    * @param cases - Both `left` and `right` handlers must be provided.
    */
-  abstract match<T>(cases: EitherMatch<L, R, T>): T
+  match<T>(cases: EitherMatch<L, R, T>): T {
+    if (this.isLeft()) {
+      return cases.left(this.value as L)
+    }
+    return cases.right(this.value as R)
+  }
 
   /**
    * Maps the right value through `fn`, leaving a left untouched.
@@ -153,10 +158,6 @@ export class Left<L, R = never> extends Either<L, R> {
     return false
   }
 
-  match<T>(cases: EitherMatch<L, R, T>): T {
-    return cases.left(this.value)
-  }
-
   transform<T>(fn: (value: R) => Promise<T>): AsyncEither<L, T>
   transform<T>(fn: (value: R) => T): Either<L, T>
   transform<T>(
@@ -207,10 +208,6 @@ export class Right<R, L = never> extends Either<L, R> {
 
   isRight(): this is Right<R, L> {
     return true
-  }
-
-  match<T>(cases: EitherMatch<L, R, T>): T {
-    return cases.right(this.value)
   }
 
   transform<T>(fn: (value: R) => Promise<T>): AsyncEither<L, T>

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -61,7 +61,12 @@ export abstract class Maybe<T> {
     return this
   }
 
-  abstract match<U>(cases: MaybeMatch<T, U>): U
+  match<U>(cases: MaybeMatch<T, U>): U {
+    if (this.isJust()) {
+      return cases.just(this.value)
+    }
+    return cases.nothing()
+  }
 
   /**
    * Maps the value through `fn`, leaving Nothing untouched.
@@ -100,10 +105,6 @@ export class Just<T> extends Maybe<T> {
 
   isJust(): this is Just<T> {
     return true
-  }
-
-  match<U>(cases: MaybeMatch<T, U>): U {
-    return cases.just(this.value)
   }
 
   transform<U>(fn: (value: T) => Promise<U>): AsyncMaybe<U>
@@ -154,10 +155,6 @@ export class Nothing extends Maybe<never> {
 
   isJust(): this is Just<never> {
     return false
-  }
-
-  match<U>(cases: MaybeMatch<never, U>): U {
-    return cases.nothing()
   }
 
   transform<U>(fn: (value: never) => Promise<U>): AsyncMaybe<U>


### PR DESCRIPTION
Same `rollup-plugin-dts` bug as `on()` and `isNothing()`: abstract generic methods are silently dropped from the published `.d.ts`. `match()` was missing from `Maybe<T>` and `Either<L,R>`.

Fix: implement `match()` in the base classes using `isJust()`/`isLeft()` dispatch, removing the now-redundant overrides from `Just`, `Nothing`, `Left`, and `Right`.