### PR TITLE
ci: create lightweight tag when no message is generated

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -53,5 +53,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v$VERSION" -m "${TAG_MESSAGE}"
+          if [ -n "$TAG_MESSAGE" ]; then
+            git tag -a "v$VERSION" -m "${TAG_MESSAGE}"
+          else
+            git tag "v$VERSION"
+          fi
           git push origin "v$VERSION"


### PR DESCRIPTION
## Summary

- When the Haiku API call produces no message (e.g. no API credits), create a lightweight tag instead of an annotated tag with an empty description

🤖 Generated with [Claude Code](https://claude.com/claude-code)